### PR TITLE
feat: add Jest testing setup with basic test suite

### DIFF
--- a/front-end/jest.config.js
+++ b/front-end/jest.config.js
@@ -1,0 +1,35 @@
+/** @type {import('jest').Config} */
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: {
+        jsx: 'react-jsx',
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+        module: 'esnext',
+        target: 'es2020',
+      }
+    }],
+  },
+
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  testMatch: [
+    '<rootDir>/src/**/__tests__/**/*.(ts|tsx|js)',
+    '<rootDir>/src/**/?(*.)(spec|test).(ts|tsx|js)'
+  ],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/main.tsx',
+    '!src/vite-env.d.ts'
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+};

--- a/front-end/src/__tests__/basic.test.ts
+++ b/front-end/src/__tests__/basic.test.ts
@@ -1,0 +1,53 @@
+// Testes básicos para verificar se Jest está funcionando
+
+describe('Testes Básicos da Aplicação', () => {
+  it('deve somar números corretamente', () => {
+    expect(2 + 2).toBe(4);
+  });
+
+  it('deve verificar strings', () => {
+    const appName = 'CIn Chat';
+    expect(appName).toBe('CIn Chat');
+    expect(appName.length).toBeGreaterThan(0);
+  });
+
+  it('deve trabalhar com arrays', () => {
+    const features = ['login', 'chat', 'registro'];
+    expect(features).toHaveLength(3);
+    expect(features).toContain('login');
+  });
+
+  it('deve trabalhar com objetos', () => {
+    const user = {
+      email: 'test@cin.ufpe.br',
+      isAuthenticated: false
+    };
+    
+    expect(user.email).toBe('test@cin.ufpe.br');
+    expect(user.isAuthenticated).toBe(false);
+    expect(user).toHaveProperty('email');
+  });
+
+  it('deve testar funções', () => {
+    const validateEmail = (email: string) => email.includes('@cin.ufpe.br');
+    
+    expect(validateEmail('test@cin.ufpe.br')).toBe(true);
+    expect(validateEmail('test@gmail.com')).toBe(false);
+  });
+
+  it('deve testar promises', async () => {
+    const mockApiCall = () => Promise.resolve({ status: 'success' });
+    
+    const result = await mockApiCall();
+    expect(result.status).toBe('success');
+  });
+
+  it('deve testar mock functions', () => {
+    const mockFn = jest.fn();
+    mockFn('test');
+    
+    expect(mockFn).toHaveBeenCalled();
+    expect(mockFn).toHaveBeenCalledWith('test');
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front-end/src/jest.d.ts
+++ b/front-end/src/jest.d.ts
@@ -1,0 +1,15 @@
+import '@testing-library/jest-dom';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeInTheDocument(): R;
+      toHaveValue(value: string | number): R;
+      toHaveAttribute(attribute: string, value?: string): R;
+      toBeDisabled(): R;
+      toHaveLength(length: number): R;
+    }
+  }
+}
+
+export {};

--- a/front-end/src/setupTests.ts
+++ b/front-end/src/setupTests.ts
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom';
+
+// Mock do import.meta para Vite
+Object.defineProperty(global, 'import', {
+  value: {
+    meta: {
+      env: {
+        VITE_SERVER_PATH: 'http://localhost:3000'
+      }
+    }
+  }
+});
+
+// Mock do localStorage
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+};
+global.localStorage = localStorageMock as any;
+
+// Mock do fetch
+global.fetch = jest.fn();
+
+// Mock do console.error para testes mais limpos
+const originalError = console.error;
+beforeAll(() => {
+  console.error = (...args: any[]) => {
+    if (
+      typeof args[0] === 'string' &&
+      args[0].includes('Warning: ReactDOM.render is deprecated')
+    ) {
+      return;
+    }
+    originalError.call(console, ...args);
+  };
+});
+
+afterAll(() => {
+  console.error = originalError;
+});
+
+// Limpar mocks após cada teste
+afterEach(() => {
+  jest.clearAllMocks();
+});

--- a/front-end/src/types/__tests__/auth.test.ts
+++ b/front-end/src/types/__tests__/auth.test.ts
@@ -1,0 +1,72 @@
+import { User, AuthState, LoginCredentials, RegisterCredentials } from '../auth';
+
+describe('Auth Types', () => {
+  describe('User interface', () => {
+    it('deve aceitar usuário com email obrigatório', () => {
+      const user: User = {
+        email: 'test@cin.ufpe.br'
+      };
+      expect(user.email).toBe('test@cin.ufpe.br');
+      expect(user.name).toBeUndefined();
+    });
+
+    it('deve aceitar usuário com email e nome', () => {
+      const user: User = {
+        email: 'test@cin.ufpe.br',
+        name: 'Usuário de Teste'
+      };
+      expect(user.email).toBe('test@cin.ufpe.br');
+      expect(user.name).toBe('Usuário de Teste');
+    });
+  });
+
+  describe('AuthState interface', () => {
+    it('deve representar estado não autenticado', () => {
+      const authState: AuthState = {
+        user: null,
+        token: null,
+        isAuthenticated: false
+      };
+      expect(authState.isAuthenticated).toBe(false);
+      expect(authState.user).toBeNull();
+      expect(authState.token).toBeNull();
+    });
+
+    it('deve representar estado autenticado', () => {
+      const authState: AuthState = {
+        user: { email: 'test@cin.ufpe.br', name: 'Test User' },
+        token: 'jwt-token',
+        isAuthenticated: true
+      };
+      expect(authState.isAuthenticated).toBe(true);
+      expect(authState.user).toBeDefined();
+      expect(authState.token).toBe('jwt-token');
+    });
+  });
+
+  describe('LoginCredentials interface', () => {
+    it('deve aceitar credenciais válidas', () => {
+      const credentials: LoginCredentials = {
+        email: 'test@cin.ufpe.br',
+        password: 'password123'
+      };
+      expect(credentials.email).toBe('test@cin.ufpe.br');
+      expect(credentials.password).toBe('password123');
+    });
+  });
+
+  describe('RegisterCredentials interface', () => {
+    it('deve aceitar credenciais de registro válidas', () => {
+      const credentials: RegisterCredentials = {
+        name: 'Usuário de Teste',
+        email: 'test@cin.ufpe.br',
+        password: 'password123',
+        confirmPassword: 'password123'
+      };
+      expect(credentials.name).toBe('Usuário de Teste');
+      expect(credentials.email).toBe('test@cin.ufpe.br');
+      expect(credentials.password).toBe('password123');
+      expect(credentials.confirmPassword).toBe('password123');
+    });
+  });
+});

--- a/front-end/src/types/__tests__/chat.test.ts
+++ b/front-end/src/types/__tests__/chat.test.ts
@@ -1,0 +1,86 @@
+import { Message, Chat, CreateChatRequest, SendMessageRequest } from '../chat';
+
+describe('Chat Types', () => {
+  describe('Message interface', () => {
+    it('deve criar mensagem do usuário', () => {
+      const message: Message = {
+        id: '1',
+        text: 'Olá, como você está?',
+        isUser: true,
+        createdAt: new Date('2024-01-01T10:00:00Z')
+      };
+      expect(message.isUser).toBe(true);
+      expect(message.text).toBe('Olá, como você está?');
+      expect(message.id).toBe('1');
+    });
+
+    it('deve criar mensagem do bot/assistente', () => {
+      const message: Message = {
+        id: '2',
+        text: 'Olá! Estou bem, obrigado por perguntar.',
+        isUser: false,
+        createdAt: new Date('2024-01-01T10:01:00Z')
+      };
+      expect(message.isUser).toBe(false);
+      expect(message.text).toBe('Olá! Estou bem, obrigado por perguntar.');
+    });
+  });
+
+  describe('Chat interface', () => {
+    it('deve criar chat sem mensagens', () => {
+      const chat: Chat = {
+        id: '1',
+        name: 'Chat de Teste',
+        createdAt: new Date('2024-01-01T09:00:00Z'),
+        userId: 1
+      };
+      expect(chat.messages).toBeUndefined();
+      expect(chat.name).toBe('Chat de Teste');
+      expect(chat.userId).toBe(1);
+    });
+
+    it('deve criar chat com mensagens', () => {
+      const messages: Message[] = [
+        {
+          id: '1',
+          text: 'Primeira mensagem',
+          isUser: true,
+          createdAt: new Date()
+        }
+      ];
+      
+      const chat: Chat = {
+        id: '1',
+        name: 'Chat com Mensagens',
+        createdAt: new Date('2024-01-01T09:00:00Z'),
+        userId: 1,
+        messages
+      };
+      
+      expect(chat.messages).toHaveLength(1);
+      expect(chat.messages?.[0].text).toBe('Primeira mensagem');
+    });
+  });
+
+  describe('CreateChatRequest interface', () => {
+    it('deve criar request de chat válido', () => {
+      const request: CreateChatRequest = {
+        name: 'Novo Chat',
+        userId: 123
+      };
+      expect(request.name).toBe('Novo Chat');
+      expect(request.userId).toBe(123);
+    });
+  });
+
+  describe('SendMessageRequest interface', () => {
+    it('deve criar request de mensagem válido', () => {
+      const request: SendMessageRequest = {
+        chatId: 456,
+        text: 'Esta é uma nova mensagem'
+      };
+      expect(request.chatId).toBe(456);
+      expect(request.text).toBe('Esta é uma nova mensagem');
+    });
+  });
+});


### PR DESCRIPTION
## :clipboard: Descrição da Feature

Uma descrição clara e concisa da nova feature.

### :ballot_box_with_check: Implementações Feitas

- [ ] Instalação e configuração do Jest para React + TypeScript
- [ ] Configuração do ambiente jsdom para simular DOM do navegador
- [ ] npm test - Executar todos os testes
- [ ] npm run test:watch - Modo watch (reexecuta automaticamente)

⚠️ Limitações Conhecidas:
- Testes de componentes React não funcionam devido a conflitos Vite/Jest
- import.meta do Vite não é compatível com Jest
- Dependências externas (lucide-react, @radix-ui) não são resolvidas nos testes